### PR TITLE
Add setting of outdir and also a temp file while writing

### DIFF
--- a/src/x3f_extract.c
+++ b/src/x3f_extract.c
@@ -249,6 +249,7 @@ int main(int argc, char *argv[])
 
   extract_meta =
     file_type == META ||
+    file_type == DNG ||
     (extract_raw &&
      (crop || (color_encoding != UNPROCESSED && color_encoding != QTOP)));
 
@@ -284,18 +285,19 @@ int main(int argc, char *argv[])
     }
 
     if (extract_meta) {
-      /* We assume we do not need JPEG meta data
-	 x3f_load_data(x3f, x3f_get_thumb_jpeg(x3f)); */
+      x3f_directory_entry_t *DE = x3f_get_prop(x3f);
+
       if (X3F_OK != x3f_load_data(x3f, x3f_get_camf(x3f))) {
 	fprintf(stderr, "Could not load CAMF from file\n");
 	goto found_error;
       }
-      if (x3f_get_camf_type(x3f) < 5)
+      if (DE != NULL)
 	/* Not for Quattro */
-	if (X3F_OK != x3f_load_data(x3f, x3f_get_prop(x3f))) {
+	if (X3F_OK != x3f_load_data(x3f, DE)) {
 	  fprintf(stderr, "Could not load PROP from file\n");
 	  goto found_error;
 	}
+      /* We do not load any JPEG meta data */
     }
 
     if (extract_raw) {

--- a/src/x3f_io.c
+++ b/src/x3f_io.c
@@ -1950,15 +1950,6 @@ static void x3f_load_camf(x3f_info_t *I, x3f_directory_entry_t *DE)
   return X3F_OK;
 }
 
-/* extern */ uint32_t x3f_get_camf_type(x3f_t *x3f)
-{
-  x3f_directory_entry_t *DE = x3f_get_camf(x3f);
-  x3f_directory_entry_header_t *DEH = &DE->header;
-  x3f_camf_t *CAMF = &DEH->data_subsection.camf;
-
-  return CAMF->type;
-}
-
 /* extern */ char *x3f_err(x3f_return_t err)
 {
   switch (err) {

--- a/src/x3f_io.h
+++ b/src/x3f_io.h
@@ -445,8 +445,6 @@ extern x3f_return_t x3f_load_data(x3f_t *x3f, x3f_directory_entry_t *DE);
 
 extern x3f_return_t x3f_load_image_block(x3f_t *x3f, x3f_directory_entry_t *DE);
 
-extern uint32_t x3f_get_camf_type(x3f_t *x3f);
-
 extern char *x3f_err(x3f_return_t err);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This pull request makes it possible to choose the directory for the ouput file.
It also writes the output to a temporary file that later is renamed to the correct file name.
The latter is neccessary in order to not trigger e.g. LR that it has got a new DNG file.
