### PR TITLE
Fix reading of X3F header

### DIFF
--- a/features/consistency.feature
+++ b/features/consistency.feature
@@ -12,7 +12,7 @@ Examples: images
 | x3f_test_files/_SDI8040.X3F | TIFF | x3f_test_files/_SDI8040.X3F.tif | cb67d12ec0a4fd318a426276f527f1a9 |
 | x3f_test_files/_SDI8040.X3F | PPM | x3f_test_files/_SDI8040.X3F.ppm | a2bea89af18bb24efd289b73007b2413 |
 | x3f_test_files/_SDI8040.X3F | JPG | x3f_test_files/_SDI8040.X3F.jpg | 357f126f6435345642bfbc6171745d00 |
-| x3f_test_files/_SDI8040.X3F | META | x3f_test_files/_SDI8040.X3F.meta | 6a29dd5d1284e453bcf6807f230d7180 |
+| x3f_test_files/_SDI8040.X3F | META | x3f_test_files/_SDI8040.X3F.meta | 2e81db66465fa97366e64b943324a514 |
 | x3f_test_files/_SDI8040.X3F | RAW | x3f_test_files/_SDI8040.X3F.raw | 89582789c24f86aaefd92395bc4f0572 |
 | x3f_test_files/_SDI8040.X3F | PPM-ASCII | x3f_test_files/_SDI8040.X3F.ppm | 74e6652a6a1325949d086bc9f099fbe7 |
 | x3f_test_files/_SDI8040.X3F | HISTOGRAM | x3f_test_files/_SDI8040.X3F.csv | 8ad3868b2c7b871555932a783c16397d |
@@ -22,7 +22,7 @@ Examples: images
 | x3f_test_files/_SDI8284.X3F | TIFF | x3f_test_files/_SDI8284.X3F.tif | 26199384d894ae723292e5ecc40ad194 |
 | x3f_test_files/_SDI8284.X3F | PPM | x3f_test_files/_SDI8284.X3F.ppm | 06c85f54fe3a954d4e564efbbb8d8a8b |
 | x3f_test_files/_SDI8284.X3F | JPG | x3f_test_files/_SDI8284.X3F.jpg | 87cd494d3bc4eab4e481de6afeb058de |
-| x3f_test_files/_SDI8284.X3F | META | x3f_test_files/_SDI8284.X3F.meta | d93655234be234bdb6c49183bc683eea |
+| x3f_test_files/_SDI8284.X3F | META | x3f_test_files/_SDI8284.X3F.meta | 0a77d95cf4f53acec52c11e756590a28 |
 | x3f_test_files/_SDI8284.X3F | RAW | x3f_test_files/_SDI8284.X3F.raw | b9d230401b9822978b49ec244c2f0668 |
 | x3f_test_files/_SDI8284.X3F | PPM-ASCII | x3f_test_files/_SDI8284.X3F.ppm | cf48c36eddbddccefcf44378d2e45ba8 |
 | x3f_test_files/_SDI8284.X3F | HISTOGRAM | x3f_test_files/_SDI8284.X3F.csv | 78edd0177ac057d77ed62d560267b640 |

--- a/src/x3f_io.c
+++ b/src/x3f_io.c
@@ -299,20 +299,24 @@ static x3f_huffman_t *new_huffman(x3f_huffman_t **HUFP)
 
   GET4(H->version);
   GETN(H->unique_identifier, SIZE_UNIQUE_IDENTIFIER);
-  GET4(H->mark_bits);
-  GET4(H->columns);
-  GET4(H->rows);
-  GET4(H->rotation);
-  if (H->version >= X3F_VERSION_2_1) {
-    int num_ext_data =
-      H->version >= X3F_VERSION_3_0 ? NUM_EXT_DATA_3_0 : NUM_EXT_DATA_2_1;
+  /* TODO: the meaning of the rest of the header for version >= 4.0
+           (Quattro) is unknown */
+  if (H->version < X3F_VERSION_4_0) {
+    GET4(H->mark_bits);
+    GET4(H->columns);
+    GET4(H->rows);
+    GET4(H->rotation);
+    if (H->version >= X3F_VERSION_2_1) {
+      int num_ext_data =
+	H->version >= X3F_VERSION_3_0 ? NUM_EXT_DATA_3_0 : NUM_EXT_DATA_2_1;
 
-    GETN(H->white_balance, SIZE_WHITE_BALANCE);
-    if (H->version >= X3F_VERSION_2_3)
-      GETN(H->color_mode, SIZE_COLOR_MODE);
-    GETN(H->extended_types, num_ext_data);
-    for (i=0; i<num_ext_data; i++)
-      GET4F(H->extended_data[i]);
+      GETN(H->white_balance, SIZE_WHITE_BALANCE);
+      if (H->version >= X3F_VERSION_2_3)
+	GETN(H->color_mode, SIZE_COLOR_MODE);
+      GETN(H->extended_types, num_ext_data);
+      for (i=0; i<num_ext_data; i++)
+	GET4F(H->extended_data[i]);
+    }
   }
 
   /* Go to the beginning of the directory */

--- a/src/x3f_io.h
+++ b/src/x3f_io.h
@@ -27,11 +27,18 @@ extern "C" {
 
 #define SIZE_UNIQUE_IDENTIFIER 16
 #define SIZE_WHITE_BALANCE 32
-#define NUM_EXT_DATA 32
+#define SIZE_COLOR_MODE 32
+#define NUM_EXT_DATA_2_1 32
+#define NUM_EXT_DATA_3_0 64
+#define NUM_EXT_DATA NUM_EXT_DATA_3_0
 
 #define X3F_VERSION(MAJ,MIN) (uint32_t)(((MAJ)<<16) + MIN)
 #define X3F_VERSION_2_0 X3F_VERSION(2,0)
 #define X3F_VERSION_2_1 X3F_VERSION(2,1)
+#define X3F_VERSION_2_2 X3F_VERSION(2,2)
+#define X3F_VERSION_2_3 X3F_VERSION(2,3)
+#define X3F_VERSION_3_0 X3F_VERSION(3,0)
+#define X3F_VERSION_4_0 X3F_VERSION(4,0)
 
 /* Main file identifier */
 #define X3F_FOVb (uint32_t)(0x62564f46)
@@ -397,8 +404,10 @@ typedef struct x3f_header_s {
   uint32_t rows;                /* ... before rotation */
   uint32_t rotation;            /* 0, 90, 180, 270 */
 
-  /* Added for 2.1 and 2.2 */
-  char white_balance[SIZE_WHITE_BALANCE];
+  char white_balance[SIZE_WHITE_BALANCE]; /* Introduced in 2.1 */
+  char color_mode[SIZE_COLOR_MODE]; /* Introduced in 2.3 */
+
+  /* Introduced in 2.1 and extended from 32 to 64 in 3.0 */
   uint8_t extended_types[NUM_EXT_DATA]; /* x3f_extended_types_t */
   float extended_data[NUM_EXT_DATA]; /* 32 bits, but do type differ? */
 } x3f_header_t;

--- a/src/x3f_print.c
+++ b/src/x3f_print.c
@@ -131,26 +131,30 @@ static void print_file_header_meta_data(FILE *f_out, x3f_t *x3f)
   fprintf(f_out, "header.\n");
   fprintf(f_out, "  identifier        = %08x (%s)\n", H->identifier, x3f_id(H->identifier));
   fprintf(f_out, "  version           = %08x\n", H->version);
-  fprintf(f_out, "  unique_identifier = %02x...\n", H->unique_identifier[0]);
-  fprintf(f_out, "  mark_bits         = %08x\n", H->mark_bits);
-  fprintf(f_out, "  columns           = %08x (%d)\n", H->columns, H->columns);
-  fprintf(f_out, "  rows              = %08x (%d)\n", H->rows, H->rows);
-  fprintf(f_out, "  rotation          = %08x (%d)\n", H->rotation, H->rotation);
-  if (x3f->header.version >= X3F_VERSION_2_1) {
-    int num_ext_data =
-      H->version >= X3F_VERSION_3_0 ? NUM_EXT_DATA_3_0 : NUM_EXT_DATA_2_1;
-    int i;
+  /* TODO: the meaning of the rest of the header for version >= 4.0
+           (Quattro) is unknown */
+  if (H->version < X3F_VERSION_4_0) {
+    fprintf(f_out, "  unique_identifier = %02x...\n", H->unique_identifier[0]);
+    fprintf(f_out, "  mark_bits         = %08x\n", H->mark_bits);
+    fprintf(f_out, "  columns           = %08x (%d)\n", H->columns, H->columns);
+    fprintf(f_out, "  rows              = %08x (%d)\n", H->rows, H->rows);
+    fprintf(f_out, "  rotation          = %08x (%d)\n", H->rotation, H->rotation);
+    if (x3f->header.version >= X3F_VERSION_2_1) {
+      int num_ext_data =
+	H->version >= X3F_VERSION_3_0 ? NUM_EXT_DATA_3_0 : NUM_EXT_DATA_2_1;
+      int i;
 
-    fprintf(f_out, "  white_balance     = %s\n", H->white_balance);
-    if (x3f->header.version >= X3F_VERSION_2_3)
-      fprintf(f_out, "  color_mode        = %s\n", H->color_mode);
+      fprintf(f_out, "  white_balance     = %s\n", H->white_balance);
+      if (x3f->header.version >= X3F_VERSION_2_3)
+	fprintf(f_out, "  color_mode        = %s\n", H->color_mode);
 
-    fprintf(f_out, "  extended_types\n");
-    for (i=0; i<num_ext_data; i++) {
-      uint8_t type = H->extended_types[i];
-      float data = H->extended_data[i];
+      fprintf(f_out, "  extended_types\n");
+      for (i=0; i<num_ext_data; i++) {
+	uint8_t type = H->extended_types[i];
+	float data = H->extended_data[i];
 
-      fprintf(f_out, "    %2d: %3d = %9f\n", i, type, data);
+	fprintf(f_out, "    %2d: %3d = %9f\n", i, type, data);
+      }
     }
   }
 

--- a/src/x3f_print.c
+++ b/src/x3f_print.c
@@ -136,13 +136,17 @@ static void print_file_header_meta_data(FILE *f_out, x3f_t *x3f)
   fprintf(f_out, "  columns           = %08x (%d)\n", H->columns, H->columns);
   fprintf(f_out, "  rows              = %08x (%d)\n", H->rows, H->rows);
   fprintf(f_out, "  rotation          = %08x (%d)\n", H->rotation, H->rotation);
-  if (x3f->header.version > X3F_VERSION_2_0) {
+  if (x3f->header.version >= X3F_VERSION_2_1) {
+    int num_ext_data =
+      H->version >= X3F_VERSION_3_0 ? NUM_EXT_DATA_3_0 : NUM_EXT_DATA_2_1;
     int i;
 
     fprintf(f_out, "  white_balance     = %s\n", H->white_balance);
+    if (x3f->header.version >= X3F_VERSION_2_3)
+      fprintf(f_out, "  color_mode        = %s\n", H->color_mode);
 
     fprintf(f_out, "  extended_types\n");
-    for (i=0; i<NUM_EXT_DATA; i++) {
+    for (i=0; i<num_ext_data; i++) {
       uint8_t type = H->extended_types[i];
       float data = H->extended_data[i];
 


### PR DESCRIPTION
This fixes two issues.

#62: Correct decoding of header up to version 3.0. The field color_mode is introduced in version 2.3 and the number of extended data is increased from 32 to 64 in version 3.0.
#61: Ignoring the unknown part of the header for X3F version >= 4.0 (Quatto). Maybe not exactly a fix, but rather damage control.

All test cases are passing. The checksums for metadata obviously had to be updated.

