### PR TITLE
Add support for sd Quattro

### DIFF
--- a/src/x3f_io.c
+++ b/src/x3f_io.c
@@ -556,6 +556,9 @@ static x3f_directory_entry_t *x3f_get(x3f_t *x3f,
   if ((DE = x3f_get(x3f, X3F_SECi, X3F_IMAGE_RAW_QUATTRO)) != NULL)
     return DE;
 
+  if ((DE = x3f_get(x3f, X3F_SECi, X3F_IMAGE_RAW_SDQ)) != NULL)
+    return DE;
+
   return NULL;
 }
 
@@ -843,7 +846,8 @@ static void true_decode_one_color(x3f_image_data_t *ID, int color)
   row_start_acc[1][0] = seed;
   row_start_acc[1][1] = seed;
 
-  if (ID->type_format == X3F_IMAGE_RAW_QUATTRO) {
+  if (ID->type_format == X3F_IMAGE_RAW_QUATTRO ||
+      ID->type_format == X3F_IMAGE_RAW_SDQ) {
     rows = Q->plane[color].rows;
     cols = Q->plane[color].columns;
 
@@ -1192,7 +1196,8 @@ static void x3f_load_true(x3f_info_t *I,
   x3f_quattro_t *Q = NULL;
   int i;
 
-  if (ID->type_format == X3F_IMAGE_RAW_QUATTRO) {
+  if (ID->type_format == X3F_IMAGE_RAW_QUATTRO ||
+      ID->type_format == X3F_IMAGE_RAW_SDQ) {
     x3f_printf(DEBUG, "Load Quattro extra info\n");
 
     Q = new_quattro(&ID->quattro);
@@ -1223,7 +1228,8 @@ static void x3f_load_true(x3f_info_t *I,
   GET2(TRU->unknown);
   GET_TRUE_HUFF_TABLE(TRU->table);
 
-  if (ID->type_format == X3F_IMAGE_RAW_QUATTRO) {
+  if (ID->type_format == X3F_IMAGE_RAW_QUATTRO ||
+      ID->type_format == X3F_IMAGE_RAW_SDQ) {
 
     x3f_printf(DEBUG, "Load Quattro extra info 2\n");
 
@@ -1250,8 +1256,9 @@ static void x3f_load_true(x3f_info_t *I,
       TRU->plane_address[i-1] +
       (((TRU->plane_size.element[i-1] + 15) / 16) * 16);
 
-  if (ID->type_format == X3F_IMAGE_RAW_QUATTRO &&
-      Q->quattro_layout) {
+  if ( (ID->type_format == X3F_IMAGE_RAW_QUATTRO ||
+	ID->type_format == X3F_IMAGE_RAW_SDQ ) &&
+       Q->quattro_layout) {
     uint32_t columns = Q->plane[0].columns;
     uint32_t rows = Q->plane[0].rows;
     uint32_t channels = 3;
@@ -1407,6 +1414,7 @@ static void x3f_load_image(x3f_info_t *I, x3f_directory_entry_t *DE)
   case X3F_IMAGE_RAW_TRUE:
   case X3F_IMAGE_RAW_MERRILL:
   case X3F_IMAGE_RAW_QUATTRO:
+  case X3F_IMAGE_RAW_SDQ:
     x3f_load_true(I, DE);
     break;
   case X3F_IMAGE_RAW_HUFFMAN_X530:

--- a/src/x3f_io.h
+++ b/src/x3f_io.h
@@ -51,7 +51,7 @@ extern "C" {
 #define X3F_IMAG (uint32_t)(0x46414d49)
 #define X3F_IMA2 (uint32_t)(0x32414d49)
 #define X3F_SECi (uint32_t)(0x69434553)
-/* CAMF identifiers */
+/* CAMF section identifiers */
 #define X3F_CAMF (uint32_t)(0x464d4143)
 #define X3F_SECc (uint32_t)(0x63434553)
 /* CAMF entry identifiers */
@@ -59,16 +59,21 @@ extern "C" {
 #define X3F_CMbT (uint32_t)(0x54624d43)
 #define X3F_CMbM (uint32_t)(0x4d624d43)
 #define X3F_CMb  (uint32_t)(0x00624d43)
+/* SDQ section identifiers ? - TODO */
+#define X3F_SPPA (uint32_t)(0x41505053)
+#define X3F_SECs (uint32_t)(0x73434553)
 
 #define X3F_IMAGE_THUMB_PLAIN       (uint32_t)(0x00020003)
 #define X3F_IMAGE_THUMB_HUFFMAN     (uint32_t)(0x0002000b)
 #define X3F_IMAGE_THUMB_JPEG        (uint32_t)(0x00020012)
+#define X3F_IMAGE_THUMB_SDQ         (uint32_t)(0x00020019)  /* SDQ ? - TODO */
 
 #define X3F_IMAGE_RAW_HUFFMAN_X530  (uint32_t)(0x00030005)
 #define X3F_IMAGE_RAW_HUFFMAN_10BIT (uint32_t)(0x00030006)
 #define X3F_IMAGE_RAW_TRUE          (uint32_t)(0x0003001e)
 #define X3F_IMAGE_RAW_MERRILL       (uint32_t)(0x0001001e)
 #define X3F_IMAGE_RAW_QUATTRO       (uint32_t)(0x00010023)
+#define X3F_IMAGE_RAW_SDQ           (uint32_t)(0x00010025)
 
 #define X3F_IMAGE_HEADER_SIZE 28
 #define X3F_CAMF_HEADER_SIZE 28


### PR DESCRIPTION
Our code does not support the latest camera, the sd Quattro.

As far as I can see, it is just a matter of update the image format from 0x23 to 0x25. So, I added another macro for testing for format and tested for 0x23 OR 0x25.

I have tested it with sd Quattro files, and it seems to work.

Just as a comment - there are two new sections in the file format, one thumbnail image section and one SPPA section, whatever that is. I added those to the header file.