### PR TITLE
Clean up printing

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -94,10 +94,10 @@ else
 
 -include $(BINDIR)/*.d
 
-$(BINDIR)/x3f_extract$(EXE): $(addprefix $(BINDIR)/,x3f_extract.o x3f_io.o x3f_process.o x3f_meta.o x3f_image.o x3f_spatial_gain.o x3f_output_dng.o x3f_output_tiff.o x3f_output_ppm.o x3f_histogram.o x3f_print.o x3f_dump.o x3f_matrix.o x3f_dngtags.o x3f_denoise_utils.o x3f_denoise_aniso.o x3f_denoise.o x3f_printf.o $(AUXOBJS)) $(OCV_LIBS) $(TIFF_LIBS)
+$(BINDIR)/x3f_extract$(EXE): $(addprefix $(BINDIR)/,x3f_extract.o x3f_io.o x3f_process.o x3f_meta.o x3f_image.o x3f_spatial_gain.o x3f_output_dng.o x3f_output_tiff.o x3f_output_ppm.o x3f_histogram.o x3f_print_meta.o x3f_dump.o x3f_matrix.o x3f_dngtags.o x3f_denoise_utils.o x3f_denoise_aniso.o x3f_denoise.o x3f_printf.o $(AUXOBJS)) $(OCV_LIBS) $(TIFF_LIBS)
 	$(CXX) $^ -o $@ $(LDFLAGS) -lm
 
-$(BINDIR)/x3f_io_test$(EXE): $(addprefix $(BINDIR)/,x3f_io_test.o x3f_io.o x3f_print.o x3f_printf.o $(AUXOBJS))
+$(BINDIR)/x3f_io_test$(EXE): $(addprefix $(BINDIR)/,x3f_io_test.o x3f_io.o x3f_print_meta.o x3f_printf.o $(AUXOBJS))
 	$(CC) $^ -o $@ $(LDFLAGS)
 
 $(BINDIR)/x3f_matrix_test$(EXE): $(addprefix $(BINDIR)/,x3f_matrix_test.o x3f_matrix.o x3f_printf.o $(AUXOBJS))

--- a/src/x3f_denoise.cpp
+++ b/src/x3f_denoise.cpp
@@ -130,7 +130,7 @@ void x3f_set_use_opencl(int flag)
       x3f_printf(INFO, "OpenCL device name: %s\n", dev.name().c_str());
       x3f_printf(INFO, "OpenCL device version: %s\n", dev.version().c_str());
     }
-    else x3f_printf(WARN, "WARNING: OpenCL is not available\n");
+    else x3f_printf(WARN, "OpenCL is not available\n");
   }
   else x3f_printf(DEBUG, "OpenCL is disabled\n");
 }

--- a/src/x3f_extract.c
+++ b/src/x3f_extract.c
@@ -14,7 +14,7 @@
 #include "x3f_output_tiff.h"
 #include "x3f_output_ppm.h"
 #include "x3f_histogram.h"
-#include "x3f_print.h"
+#include "x3f_print_meta.h"
 #include "x3f_dump.h"
 #include "x3f_denoise.h"
 #include "x3f_printf.h"

--- a/src/x3f_image.c
+++ b/src/x3f_image.c
@@ -126,7 +126,7 @@
   if (rect[0] > keep[2] || rect[1] > keep[3] ||
       rect[2] < keep[0] || rect[3] < keep[1]) {
     x3f_printf(WARN,
-	       "WARNING: CAMF rect %s (%u,%u,%u,%u) completely out of bounds : "
+	       "CAMF rect %s (%u,%u,%u,%u) completely out of bounds : "
 	       "KeepImageArea (%u,%u,%u,%u)\n", name,
 	       rect[0], rect[1], rect[2], rect[3],
 	       keep[0], keep[1], keep[2], keep[3]);
@@ -156,7 +156,7 @@
   /* Make sure that KeepImageArea is within the bounds of image */
   else if (keep_cols > image->columns || keep_rows > image->rows) {
     x3f_printf(WARN,
-	       "WARNING: KeepImageArea (%u,%u,%u,%u) out of bounds : "
+	       "KeepImageArea (%u,%u,%u,%u) out of bounds : "
 	       "image size (%u,%u)\n",
 	       keep[0], keep[1], keep[2], keep[3],
 	       image->columns, image->rows);

--- a/src/x3f_io.c
+++ b/src/x3f_io.c
@@ -1806,8 +1806,8 @@ static void x3f_setup_camf_matrix_entry(camf_entry_t *entry)
 
     if (dentry[i].n != i) {
       /* TODO: is something needed to be made in this case */
-      x3f_printf(WARN,
-		 "WARNING: matrix entry for %s/%s is out of order "
+      x3f_printf(DEBUG,
+		 "Matrix entry for %s/%s is out of order "
 		 "(index/%d != order/%d)\n",
 		 entry->name_address, dentry[i].name, dentry[i].n, i);
     }

--- a/src/x3f_io_test.c
+++ b/src/x3f_io_test.c
@@ -8,7 +8,7 @@
  */
 
 #include "x3f_io.h"
-#include "x3f_print.h"
+#include "x3f_print_meta.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
 
   if (do_print_info) {
     printf("PRINT THE SKELETON X3F STRUCTURE\n");
-    x3f_print(x3f);
+    x3f_print_meta(x3f);
   }
 
   if (do_unpack_data) {
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
 
     if (do_print_info) {
       printf("PRINT THE UNPACKED X3F STRUCTURE\n");
-      x3f_print(x3f);
+      x3f_print_meta(x3f);
     }
   }
 

--- a/src/x3f_output_dng.c
+++ b/src/x3f_output_dng.c
@@ -411,7 +411,7 @@ x3f_return_t x3f_dump_raw_data_as_dng(x3f_t *x3f,
 
   if (apply_sgain)
     if (!write_spatial_gain(x3f, &image, wb, f_out))
-      x3f_printf(WARN, "WARNING: could not get spatial gain\n");
+      x3f_printf(WARN, "Could not get spatial gain\n");
 
   if (get_camf_rect_as_dngrect(x3f, "ActiveImageArea", &image, 1, active_area))
     TIFFSetField(f_out, TIFFTAG_ACTIVEAREA, active_area);

--- a/src/x3f_print_meta.c
+++ b/src/x3f_print_meta.c
@@ -1,4 +1,4 @@
-/* X3F_PRINT.C
+/* X3F_PRINT_META.C
  *
  * Library for printing meta data found in X3F files.
  *
@@ -7,7 +7,7 @@
  *
  */
 
-#include "x3f_print.h"
+#include "x3f_print_meta.h"
 #include "x3f_io.h"
 
 #include <stdio.h>
@@ -288,7 +288,7 @@ static void print_prop_meta_data(FILE *f_out, x3f_t *x3f)
   print_prop_meta_data2(f_out, PL);
 }
 
-/* extern */ void x3f_print(x3f_t *x3f)
+/* extern */ void x3f_print_meta(x3f_t *x3f)
 {
   int d;
   x3f_directory_section_t *DS = NULL;

--- a/src/x3f_print_meta.h
+++ b/src/x3f_print_meta.h
@@ -1,4 +1,4 @@
-/* X3F_PRINT.H
+/* X3F_PRINT_META.H
  *
  * Library for printing meta data found in X3F files.
  *
@@ -7,14 +7,14 @@
  *
  */
 
-#ifndef X3F_PRINT_H
-#define X3F_PRINT_H
+#ifndef X3F_PRINT_META_H
+#define X3F_PRINT_META_H
 
 #include "x3f_io.h"
 
 extern uint32_t max_printed_matrix_elements;
 
-extern void x3f_print(x3f_t *x3f);
+extern void x3f_print_meta(x3f_t *x3f);
 extern x3f_return_t x3f_dump_meta_data(x3f_t *x3f, char *outfilename);
 
 #endif

--- a/src/x3f_printf.c
+++ b/src/x3f_printf.c
@@ -17,10 +17,25 @@ x3f_verbosity_t x3f_printf_level = INFO;
 extern void x3f_printf(x3f_verbosity_t level, const char *fmt, ...)
 {
   va_list ap;
+  FILE *f = level > WARN ? stdout : stderr;
 
   if (level > x3f_printf_level) return;
 
+  switch(level) {
+  case ERR:
+    fprintf(f, "ERR: ");
+    break;
+  case WARN:
+    fprintf(f, "WRN: ");
+    break;
+  case INFO:
+    fprintf(f, "   : ");
+    break;
+  case DEBUG:
+    fprintf(f, "dbg: ");
+    break;
+  }
   va_start(ap, fmt);
-  vfprintf(level > WARN ? stdout : stderr, fmt, ap);
+  vfprintf(f, fmt, ap);
   va_end(ap);
 }

--- a/src/x3f_process.c
+++ b/src/x3f_process.c
@@ -274,8 +274,7 @@ typedef struct bad_pixel_s {
 	1 << (_PN((_c), (_r), (_cs)) & 0x1f);				\
     }									\
     else if (!_INB((_c), (_r), (_cs), (_rs)))				\
-      x3f_printf(WARN,							\
-		 "WARNING: bad pixel (%u,%u) out of bounds : (%u,%u)\n", \
+      x3f_printf(WARN, "Bad pixel (%u,%u) out of bounds : (%u,%u)\n",   \
 		 (_c), (_r), (_cs), (_rs));				\
   } while (0)
 
@@ -447,7 +446,7 @@ static void interpolate_bad_pixels(x3f_t *x3f, x3f_area16_t *image, int colors)
       /* If nothing else to do, accept corners */
       if (!fix_corner) fix_corner = 1;
       else {
-	x3f_printf(WARN, "WARNING: Failed to interpolate %d bad pixels\n",
+	x3f_printf(WARN, "Failed to interpolate %d bad pixels\n",
 		   stats.left);
 	fixed = bad_pixel_list;	/* Free remaining list entries */
 	bad_pixel_list = NULL;	/* Force termination */
@@ -589,7 +588,7 @@ static int get_conv(x3f_t *x3f, x3f_color_encoding_t encoding, char *wb,
   }
   else {
     iso_scaling = 1.0;
-    x3f_printf(WARN, "WARNING: could not calculate ISO scaling, assuming %g\n",
+    x3f_printf(WARN, "Could not calculate ISO scaling, assuming %g\n",
 	       iso_scaling);
   }
 
@@ -660,7 +659,7 @@ static int convert_data(x3f_t *x3f,
   if (apply_sgain) {
     sgain_num = x3f_get_spatial_gain(x3f, wb, sgain);
     if (sgain_num == 0)
-      x3f_printf(WARN, "WARNING: could not get spatial gain\n");
+      x3f_printf(WARN, "Could not get spatial gain\n");
   } else {
     sgain_num = 0;
   }
@@ -707,8 +706,7 @@ static int run_denoising(x3f_t *x3f)
   if (!x3f_image_area(x3f, &original_image)) return 0;
   if (!x3f_crop_area_camf(x3f, "ActiveImageArea", &original_image, 1, &image)) {
     image = original_image;
-    x3f_printf(WARN,
-	       "WARNING: could not get active area, denoising entire image\n");
+    x3f_printf(WARN, "Could not get active area, denoising entire image\n");
   }
 
   if (x3f_get_prop_entry(x3f, "SENSORID", &sensorid) &&
@@ -729,8 +727,7 @@ static int expand_quattro(x3f_t *x3f, int denoise, x3f_area16_t *expanded)
   if (denoise &&
       !x3f_crop_area_camf(x3f, "ActiveImageArea", &image, 1, &active)) {
     active = image;
-    x3f_printf(WARN,
-	       "WARNING: could not get active area, denoising entire image\n");
+    x3f_printf(WARN, "Could not get active area, denoising entire image\n");
   }
 
   rect[0] = 0;
@@ -749,8 +746,7 @@ static int expand_quattro(x3f_t *x3f, int denoise, x3f_area16_t *expanded)
   if (denoise && !x3f_crop_area_camf(x3f, "ActiveImageArea", expanded, 0,
 				     &active_exp)) {
     active_exp = *expanded;
-    x3f_printf(WARN,
-	       "WARNING: could not get active area, denoising entire image\n");
+    x3f_printf(WARN, "Could not get active area, denoising entire image\n");
   }
 
   x3f_expand_quattro(&image, denoise ? &active : NULL, &qtop_crop,
@@ -838,7 +834,7 @@ static int expand_quattro(x3f_t *x3f, int denoise, x3f_area16_t *expanded)
   if (apply_sgain) {
     sgain_num = x3f_get_spatial_gain(x3f, wb, sgain);
     if (sgain_num == 0)
-      x3f_printf(WARN, "WARNING: could not get spatial gain\n");
+      x3f_printf(WARN, "Could not get spatial gain\n");
   } else {
     sgain_num = 0;
   }

--- a/src/x3f_spatial_gain.c
+++ b/src/x3f_spatial_gain.c
@@ -30,7 +30,7 @@ static double get_focal_length(x3f_t *x3f)
     focal_length = atof(flength);
   else {
     focal_length = 30.0;
-    x3f_printf(WARN, "WARNING: could not get focal length, assuming %g mm\n",
+    x3f_printf(WARN, "Could not get focal length, assuming %g mm\n",
 	       focal_length);
   }
 
@@ -45,7 +45,7 @@ static double get_object_distance(x3f_t *x3f)
     object_distance *= 10.0;	/* Convert cm to mm */
   else {
     object_distance = INFINITY;
-    x3f_printf(WARN, "WARNING: could not get object distance, assuming %g mm\n",
+    x3f_printf(WARN, "Could not get object distance, assuming %g mm\n",
 	       object_distance);
   }
 
@@ -74,7 +74,7 @@ static double get_MOD(x3f_t *x3f)
     break;
   default:
     mod = 280.0;
-    x3f_printf(WARN, "WARNING: could not get MOD, assuming %g mm\n", mod);
+    x3f_printf(WARN, "Could not get MOD, assuming %g mm\n", mod);
   }
 
   return mod;


### PR DESCRIPTION
This pull request contains three cahnges

1. The call x3f_print has changed to x3f_print_meta
2. The call x3f_printf now prefixes printouts lines with e.g. "ERR: "
3. The warning for "out of order" matrices now is a DEBUG., avoiding misunderstandings.
