### PR TITLE
Print version

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -15,6 +15,13 @@
 
 include ../sys.mk
 
+# Set version stuff
+# -----------------------------------------------------------
+NAME = x3f_tools
+VER := $(shell git describe --always --dirty --tags)
+VERSION = $(VER)-$(TARGET)
+
+
 # Set compilation and load flags etc
 # -----------------------------------------------------------
 
@@ -67,6 +74,7 @@ LDFLAGS = $(LDBASE) $(L)
 
 BINDIR = ../bin/$(TARGET)
 PROGS = x3f_extract$(EXE) x3f_io_test$(EXE) x3f_matrix_test$(EXE)
+VERSION_O = x3f_version-$(VERSION).o
 
 # Build dependencies
 # -----------------------------------------------------------
@@ -94,10 +102,10 @@ else
 
 -include $(BINDIR)/*.d
 
-$(BINDIR)/x3f_extract$(EXE): $(addprefix $(BINDIR)/,x3f_extract.o x3f_io.o x3f_process.o x3f_meta.o x3f_image.o x3f_spatial_gain.o x3f_output_dng.o x3f_output_tiff.o x3f_output_ppm.o x3f_histogram.o x3f_print_meta.o x3f_dump.o x3f_matrix.o x3f_dngtags.o x3f_denoise_utils.o x3f_denoise_aniso.o x3f_denoise.o x3f_printf.o $(AUXOBJS)) $(OCV_LIBS) $(TIFF_LIBS)
+$(BINDIR)/x3f_extract$(EXE): $(addprefix $(BINDIR)/,x3f_extract.o $(VERSION_O) x3f_io.o x3f_process.o x3f_meta.o x3f_image.o x3f_spatial_gain.o x3f_output_dng.o x3f_output_tiff.o x3f_output_ppm.o x3f_histogram.o x3f_print_meta.o x3f_dump.o x3f_matrix.o x3f_dngtags.o x3f_denoise_utils.o x3f_denoise_aniso.o x3f_denoise.o x3f_printf.o $(AUXOBJS)) $(OCV_LIBS) $(TIFF_LIBS)
 	$(CXX) $^ -o $@ $(LDFLAGS) -lm
 
-$(BINDIR)/x3f_io_test$(EXE): $(addprefix $(BINDIR)/,x3f_io_test.o x3f_io.o x3f_print_meta.o x3f_printf.o $(AUXOBJS))
+$(BINDIR)/x3f_io_test$(EXE): $(addprefix $(BINDIR)/,x3f_io_test.o $(VERSION_O) x3f_io.o x3f_print_meta.o x3f_printf.o $(AUXOBJS))
 	$(CC) $^ -o $@ $(LDFLAGS)
 
 $(BINDIR)/x3f_matrix_test$(EXE): $(addprefix $(BINDIR)/,x3f_matrix_test.o x3f_matrix.o x3f_printf.o $(AUXOBJS))
@@ -109,6 +117,11 @@ $(BINDIR)/%.o: %.c | $(BINDIR)
 $(BINDIR)/%.o: %.cpp | $(BINDIR)
 	$(CXX) $(CXXFLAGS) $< -c -MD -o $@
 
+#
+
+$(BINDIR)/$(VERSION_O): x3f_version.c | $(BINDIR)
+	$(CC) -DVERSION=\"$(VERSION)\" $< -c -MD -o $@
+
 endif
 
 $(BINDIR):
@@ -117,9 +130,7 @@ $(BINDIR):
 # Packaging
 # -----------------------------------------------------------
 
-NAME = x3f_tools
-VER := $(shell git describe --always --dirty --tags)
-DIST = $(NAME)-$(VER)-$(TARGET)
+DIST = $(NAME)-$(VERSION)
 DIST_DIR = ../dist/$(DIST)
 DIST_TGZ = ../dist/$(DIST).tar.gz
 DIST_ZIP = ../dist/$(DIST).zip

--- a/src/x3f_extract.c
+++ b/src/x3f_extract.c
@@ -8,6 +8,7 @@
  *
  */
 
+#include "x3f_version.h"
 #include "x3f_io.h"
 #include "x3f_process.h"
 #include "x3f_output_dng.h"
@@ -190,6 +191,8 @@ int main(int argc, char *argv[])
   char *outdir = NULL;
 
   int i;
+
+  x3f_printf(INFO, "X3F TOOLS VERSION = %s\n\n", version);
 
   /* Set stdout and stderr to line buffered mode to avoid scrambling */
   setvbuf(stdout, NULL, _IOLBF, 0);

--- a/src/x3f_io_test.c
+++ b/src/x3f_io_test.c
@@ -7,6 +7,7 @@
  * 
  */
 
+#include "x3f_version.h"
 #include "x3f_io.h"
 #include "x3f_print_meta.h"
 
@@ -33,6 +34,8 @@ int main(int argc, char *argv[])
   char *infilename;
 
   int i;
+
+  printf("X3F TOOLS VERSION = %s\n\n", version);
 
   for (i=1; i<argc; i++)
     if (!strcmp(argv[i], "-unpack"))

--- a/src/x3f_version.c
+++ b/src/x3f_version.c
@@ -1,0 +1,10 @@
+/* X3F_VERSION.C
+ *
+ * Contains the version of X3F Tools
+ *
+ * Copyright 2016 - Roland and Erik Karlsson
+ * BSD-style - see doc/copyright.txt
+ *
+ */
+
+char *version = VERSION;

--- a/src/x3f_version.h
+++ b/src/x3f_version.h
@@ -1,0 +1,15 @@
+/* X3F_VERSION.H
+ *
+ * Contains the version of X3F Tools
+ *
+ * Copyright 2016 - Roland and Erik Karlsson
+ * BSD-style - see doc/copyright.txt
+ *
+ */
+
+#ifndef X3F_VERSION_H
+#define X3F_VERSION_H
+
+extern char *version;
+
+#endif


### PR DESCRIPTION
A file, called x3f_version.o, contains the current version, based on git tag etc.

It is compiled each time, so the version is always the current one.

This also force a link every time. If you want it more beautiful, that can be avoided at a cost of complexity in the makefile.
