### PR TITLE
Bug 95 firmware 1.0.4 error - a.k.a. - adding left/right black shields

### DIFF
--- a/src/x3f_image.c
+++ b/src/x3f_image.c
@@ -99,58 +99,23 @@
   return 1;
 }
 
-static int x3f_get_fake_camf_matrix(x3f_t *x3f, char *name,
-				    uint32_t *rect)
-{
-  uint32_t column[4];
-  int i;
-
-  if (!x3f_get_camf_matrix(x3f, "DarkShieldColRange", 2, 2, 0, M_UINT, column))
-    return 0;
-
-  if (!strcmp(name, "FakeDarkShieldLeft")) {
-    rect[0] = column[0];
-    rect[1] = 0;           /* Cropped automatically later */
-    rect[2] = column[1];
-    rect[3] = UINT32_MAX;  /* Cropped automatically later */
-    return 1;
-  }
-
-  if (!strcmp(name, "FakeDarkShieldRight")) {
-    rect[0] = column[2];
-    rect[1] = 0;           /* Cropped automatically later */
-    rect[2] = column[3];
-    rect[3] = UINT32_MAX;  /* Cropped automatically later */
-    return 1;
-  }
-
-  return 0;
-}
-
 /* NOTE: The existence of KeepImageArea and, in the case of Quattro,
-         layers with different resolution makes coordinate
-         transformation pretty complicated.
+   layers with different resolution makes coordinate
+   transformation pretty complicated.
 
-         For rescale = 0, the origin and resolution of image MUST
-         correspond to those of KeepImageArea. image can be bigger but NOT
-         smmaler than KeepImageArea.
+   For rescale = 0, the origin and resolution of image MUST
+   correspond to those of KeepImageArea. image can be bigger but NOT
+   smaller than KeepImageArea.
 
-	 For rescale = 1, the bounds of image MUST correspond exatly
-	 to those of KeepImageArea, but their resolutions can be
-	 different. */
-/* extern */ int x3f_get_camf_rect(x3f_t *x3f, char *name,
-				   x3f_area16_t *image, int rescale,
-				   uint32_t *rect)
+   For rescale = 1, the bounds of image MUST correspond exatly
+   to those of KeepImageArea, but their resolutions can be
+   different. */
+
+static int x3f_transform_rect_to_keep_image(x3f_t *x3f,
+					    x3f_area16_t *image, int rescale,
+					    uint32_t *rect)
 {
   uint32_t keep[4], keep_cols, keep_rows;
-
-  if (!strncmp(name, "Fake", 4)) {
-    if (!x3f_get_fake_camf_matrix(x3f, name, rect))
-      return 0;
-  } else {
-    if (!x3f_get_camf_matrix(x3f, name, 4, 0, 0, M_UINT, rect))
-      return 0;
-  }
 
   if (!x3f_get_camf_matrix(x3f, "KeepImageArea", 4, 0, 0, M_UINT, keep))
     return 0;
@@ -163,8 +128,8 @@ static int x3f_get_fake_camf_matrix(x3f_t *x3f, char *name,
   if (rect[0] > keep[2] || rect[1] > keep[3] ||
       rect[2] < keep[0] || rect[3] < keep[1]) {
     x3f_printf(WARN,
-	       "CAMF rect %s (%u,%u,%u,%u) completely out of bounds : "
-	       "KeepImageArea (%u,%u,%u,%u)\n", name,
+	       "CAMF rect (%u,%u,%u,%u) completely out of bounds : "
+	       "KeepImageArea (%u,%u,%u,%u)\n",
 	       rect[0], rect[1], rect[2], rect[3],
 	       keep[0], keep[1], keep[2], keep[3]);
     return 0;
@@ -203,16 +168,56 @@ static int x3f_get_fake_camf_matrix(x3f_t *x3f, char *name,
   return 1;
 }
 
+/* extern */ int x3f_get_camf_rect(x3f_t *x3f, char *name,
+				   x3f_area16_t *image, int rescale,
+				   uint32_t *rect)
+{
+  if (!x3f_get_camf_matrix(x3f, name, 4, 0, 0, M_UINT, rect))
+    return 0;
+
+  return x3f_transform_rect_to_keep_image(x3f, image, rescale, rect);
+}
+
+/* extern */ int x3f_crop_area_column(x3f_t *x3f, char *name,
+				      x3f_area16_t *image, int rescale,
+				      x3f_area16_t *crop)
+{
+  uint32_t rect[4];
+  uint32_t column[4];
+
+  if (!x3f_get_camf_matrix(x3f, "DarkShieldColRange", 2, 2, 0, M_UINT, column))
+    return 0;
+
+  rect[1] = 0;           /* Cropped automatically later */
+  rect[3] = UINT32_MAX;  /* Cropped automatically later */
+
+  if (!strcmp(name, "FakeDarkShieldLeft")) {
+    rect[0] = column[0];
+    rect[2] = column[1];
+  } else if (!strcmp(name, "FakeDarkShieldRight")) {
+    rect[0] = column[2];
+    rect[2] = column[3];
+  } else
+    return 0;
+
+  if (x3f_transform_rect_to_keep_image(x3f, image, rescale, rect)) {
+    assert(x3f_crop_area(rect, image, crop));
+    return 1;
+  }
+
+  return 0;
+}
+
 /* extern */ int x3f_crop_area_camf(x3f_t *x3f, char *name,
 				    x3f_area16_t *image, int rescale,
 				    x3f_area16_t *crop)
 {
-  uint32_t coord[4];
+  uint32_t rect[4];
 
-  if (!x3f_get_camf_rect(x3f, name, image, rescale, coord)) return 0;
+  if (!x3f_get_camf_rect(x3f, name, image, rescale, rect)) return 0;
   /* This should not fail as long as x3f_get_camf_rect is implemented
      correctly */
-  assert(x3f_crop_area(coord, image, crop));
+  assert(x3f_crop_area(rect, image, crop));
 
   return 1;
 }
@@ -221,13 +226,13 @@ static int x3f_get_fake_camf_matrix(x3f_t *x3f, char *name,
 				     x3f_area8_t *image, int rescale,
 				     x3f_area8_t *crop)
 {
-  uint32_t coord[4];
+  uint32_t rect[4];
 
-  if (!x3f_get_camf_rect(x3f, name, (x3f_area16_t *)image, rescale, coord))
+  if (!x3f_get_camf_rect(x3f, name, (x3f_area16_t *)image, rescale, rect))
     return 0;
   /* This should not fail as long as x3f_get_camf_rect is implemented
      correctly */
-  assert(x3f_crop_area8(coord, image, crop));
+  assert(x3f_crop_area8(rect, image, crop));
 
   return 1;
 }

--- a/src/x3f_image.c
+++ b/src/x3f_image.c
@@ -178,7 +178,7 @@ static int x3f_transform_rect_to_keep_image(x3f_t *x3f,
   return x3f_transform_rect_to_keep_image(x3f, image, rescale, rect);
 }
 
-/* extern */ int x3f_crop_area_column(x3f_t *x3f, char *name,
+/* extern */ int x3f_crop_area_column(x3f_t *x3f, col_side_t which_side,
 				      x3f_area16_t *image, int rescale,
 				      x3f_area16_t *crop)
 {
@@ -191,10 +191,10 @@ static int x3f_transform_rect_to_keep_image(x3f_t *x3f,
   rect[1] = 0;           /* Cropped automatically later */
   rect[3] = UINT32_MAX;  /* Cropped automatically later */
 
-  if (!strcmp(name, "FakeDarkShieldLeft")) {
+  if (which_side == COL_SIDE_LEFT) {
     rect[0] = column[0];
     rect[2] = column[1];
-  } else if (!strcmp(name, "FakeDarkShieldRight")) {
+  } else if (which_side == COL_SIDE_RIGHT) {
     rect[0] = column[2];
     rect[2] = column[3];
   } else

--- a/src/x3f_image.c
+++ b/src/x3f_image.c
@@ -100,7 +100,7 @@
 }
 
 static int x3f_get_fake_camf_matrix(x3f_t *x3f, char *name,
-				    x3f_area16_t *image, uint32_t *rect)
+				    uint32_t *rect)
 {
   uint32_t column[4];
   int i;
@@ -110,17 +110,17 @@ static int x3f_get_fake_camf_matrix(x3f_t *x3f, char *name,
 
   if (!strcmp(name, "FakeDarkShieldLeft")) {
     rect[0] = column[0];
-    rect[1] = 0;
+    rect[1] = 0;           /* Cropped automatically later */
     rect[2] = column[1];
-    rect[3] = image->rows; /* TODO - is this right? */
+    rect[3] = UINT32_MAX;  /* Cropped automatically later */
     return 1;
   }
 
   if (!strcmp(name, "FakeDarkShieldRight")) {
     rect[0] = column[2];
-    rect[1] = 0;
+    rect[1] = 0;           /* Cropped automatically later */
     rect[2] = column[3];
-    rect[3] = image->rows; /* TODO - is this right? */
+    rect[3] = UINT32_MAX;  /* Cropped automatically later */
     return 1;
   }
 
@@ -145,7 +145,7 @@ static int x3f_get_fake_camf_matrix(x3f_t *x3f, char *name,
   uint32_t keep[4], keep_cols, keep_rows;
 
   if (!strncmp(name, "Fake", 4)) {
-    if (!x3f_get_fake_camf_matrix(x3f, name, image, rect))
+    if (!x3f_get_fake_camf_matrix(x3f, name, rect))
       return 0;
   } else {
     if (!x3f_get_camf_matrix(x3f, name, 4, 0, 0, M_UINT, rect))

--- a/src/x3f_image.c
+++ b/src/x3f_image.c
@@ -14,7 +14,6 @@
 
 #include <stdio.h>
 #include <assert.h>
-#include <string.h>
 
 /* extern */ int x3f_image_area(x3f_t *x3f, x3f_area16_t *image)
 {

--- a/src/x3f_image.h
+++ b/src/x3f_image.h
@@ -21,6 +21,9 @@ extern int x3f_crop_area8(uint32_t *coord, x3f_area8_t *image,
 extern int x3f_get_camf_rect(x3f_t *x3f, char *name,
 			     x3f_area16_t *image, int rescale,
 			     uint32_t *rect);
+extern int x3f_crop_area_column(x3f_t *x3f, char *name,
+				x3f_area16_t *image, int rescale,
+				x3f_area16_t *crop);
 extern int x3f_crop_area_camf(x3f_t *x3f, char *name,
 			      x3f_area16_t *image, int rescale,
 			      x3f_area16_t *crop);

--- a/src/x3f_image.h
+++ b/src/x3f_image.h
@@ -12,6 +12,10 @@
 
 #include "x3f_io.h"
 
+typedef enum {COL_SIDE_LEFT = 0,
+	      COL_SIDE_RIGHT = 1,
+	      COL_SIDE_WRONG = 2} col_side_t;
+
 extern int x3f_image_area(x3f_t *x3f, x3f_area16_t *image);
 extern int x3f_image_area_qtop(x3f_t *x3f, x3f_area16_t *image);
 extern int x3f_crop_area(uint32_t *coord, x3f_area16_t *image,
@@ -21,7 +25,7 @@ extern int x3f_crop_area8(uint32_t *coord, x3f_area8_t *image,
 extern int x3f_get_camf_rect(x3f_t *x3f, char *name,
 			     x3f_area16_t *image, int rescale,
 			     uint32_t *rect);
-extern int x3f_crop_area_column(x3f_t *x3f, char *name,
+extern int x3f_crop_area_column(x3f_t *x3f, col_side_t which_side,
 				x3f_area16_t *image, int rescale,
 				x3f_area16_t *crop);
 extern int x3f_crop_area_camf(x3f_t *x3f, char *name,

--- a/src/x3f_process.c
+++ b/src/x3f_process.c
@@ -76,11 +76,17 @@ static int get_black_level(x3f_t *x3f,
   use[BOTTOM] = (!x3f_get_prop_entry(x3f, "CAMMODEL", &cammodel) ||
 		 strcmp(cammodel, "SIGMA DP2"));
 
-  for (i=0; i <4; i++)
+  /* Real rects */
+  for (i=0; i<2; i++)
     if (use[i])
       use[i] = x3f_crop_area_camf(x3f, name[i], image, rescale, &area[i]);
 
-  for (i=0; i <4; i++)
+  /* Fake, column based rects */
+  for (i=2; i<4; i++)
+    if (use[i])
+      use[i] = x3f_crop_area_column(x3f, name[i], image, rescale, &area[i]);
+
+  for (i=0; i<4; i++)
     if (use[i])
       x3f_printf(DEBUG, "Calculate black level for %s\n", name[i]);
     else
@@ -90,15 +96,16 @@ static int get_black_level(x3f_t *x3f,
   black_sum = alloca(colors*sizeof(uint64_t));
   memset(black_sum, 0, colors*sizeof(uint64_t));
 
+  x3f_printf(INFO, "Acc. dark level\n");
   for (i=0; i<4; i++)
     if (use[i]) {
       int color;
       pixels += sum_area(x3f, area[i], colors, black_sum);
 
+      x3f_printf(INFO, "  %s pixels = %d\n", name[i], pixels);
+
       for (color = 0; color < colors; color++)
-	x3f_printf(WARN, "XXXX %d: pixels = %d mean[%d] = %f\n",
-		   i,
-		   pixels,
+	x3f_printf(INFO, "    mean[%d] = %f\n",
 		   color,
 		   (double)black_sum[color]/pixels);
     }

--- a/src/x3f_process.c
+++ b/src/x3f_process.c
@@ -91,8 +91,16 @@ static int get_black_level(x3f_t *x3f,
   memset(black_sum, 0, colors*sizeof(uint64_t));
 
   for (i=0; i<4; i++)
-    if (use[i]) 
+    if (use[i]) {
+      int color;
       pixels += sum_area(x3f, area[i], colors, black_sum);
+
+      for (color = 0; color < colors; color++)
+	x3f_printf(WARN, "XXXX pixels = %d mean[%d] = %f\n",
+		   pixels,
+		   color,
+		   (double)black_sum[color]/pixels);
+    }
 
   if (pixels == 0) return 0;
 

--- a/src/x3f_process.c
+++ b/src/x3f_process.c
@@ -106,7 +106,7 @@ static int get_black_level(x3f_t *x3f,
   black_sum = alloca(colors*sizeof(uint64_t));
   for (i=0; i<colors; i++) black_sum[i] = 0;
 
-  x3f_printf(INFO, "Dark level\n");
+  x3f_printf(DEBUG, "Dark level\n");
 
   for (i=0; i<4; i++)
     if (use[i]) {
@@ -115,10 +115,10 @@ static int get_black_level(x3f_t *x3f,
 
       pixels_sum += pixels;
 
-      x3f_printf(INFO, "  %s (%d)\n", name[i], pixels);
+      x3f_printf(DEBUG, "  %s (%d)\n", name[i], pixels);
 
       for (color = 0; color < colors; color++) {
-	x3f_printf(INFO, "    mean[%d] = %f\n",
+	x3f_printf(DEBUG, "    mean[%d] = %f\n",
 		   color,
 		   (double)black[color]/pixels);
 	black_sum[color] += black[color];
@@ -143,10 +143,10 @@ static int get_black_level(x3f_t *x3f,
 
       pixels_sum += pixels;
 
-      x3f_printf(INFO, "  %s (%d)\n", name[i], pixels);
+      x3f_printf(DEBUG, "  %s (%d)\n", name[i], pixels);
 
       for (color = 0; color < colors; color++) {
-	x3f_printf(INFO, "    dev[%d] = %g\n",
+	x3f_printf(DEBUG, "    dev[%d] = %g\n",
 		   color,
 		   sqrt(black_sqdev[color]/pixels));
 	black_sqdev_sum[color] += black_sqdev[color]; 
@@ -155,14 +155,14 @@ static int get_black_level(x3f_t *x3f,
 
   if (pixels_sum == 0) return 0;
 
-  x3f_printf(INFO, "  SUM\n");
+  x3f_printf(DEBUG, "  SUM\n");
 
   for (i=0; i<colors; i++) {
     black_dev[i] = sqrt(black_sqdev_sum[i]/pixels_sum);
-    x3f_printf(INFO, "    level[%d] = %f\n",
+    x3f_printf(DEBUG, "    level[%d] = %f\n",
 	       i,
 	       black_level[i]);
-    x3f_printf(INFO, "    dev[%d] = %g\n",
+    x3f_printf(DEBUG, "    dev[%d] = %g\n",
 	       i,
 	       black_dev[i]);
   }

--- a/src/x3f_process.c
+++ b/src/x3f_process.c
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include <assert.h>
 
-static int sum_area(x3f_t *x3f, x3f_area16_t area, int colors,
+static int sum_area(x3f_area16_t area, int colors,
 		    uint64_t *sum)
 {
   int row, col, color;
@@ -38,8 +38,8 @@ static int sum_area(x3f_t *x3f, x3f_area16_t area, int colors,
   return area.columns*area.rows;
 }
 
-static int sum_area_sqdev(x3f_t *x3f, x3f_area16_t area, int colors,
-			  double *mean, double *sum)
+static int sum_area_sqdev(x3f_area16_t area, int colors, double *mean,
+			  double *sum)
 {
   int row, col, color;
 
@@ -111,7 +111,7 @@ static int get_black_level(x3f_t *x3f,
   for (i=0; i<4; i++)
     if (use[i]) {
       int color;
-      int pixels = sum_area(x3f, area[i], colors, black);
+      int pixels = sum_area(area[i], colors, black);
 
       pixels_sum += pixels;
 
@@ -138,8 +138,7 @@ static int get_black_level(x3f_t *x3f,
   for (i=0; i<4; i++)
     if (use[i]) {
       int color;
-      int pixels = sum_area_sqdev(x3f, area[i], colors,
-				  black_level, black_sqdev);
+      int pixels = sum_area_sqdev(area[i], colors, black_level, black_sqdev);
 
       pixels_sum += pixels;
 

--- a/src/x3f_process.c
+++ b/src/x3f_process.c
@@ -142,12 +142,7 @@ static int get_black_level(x3f_t *x3f,
 
       pixels_sum += pixels;
 
-      x3f_printf(DEBUG, "  %s (%d)\n", name[i], pixels);
-
       for (color = 0; color < colors; color++) {
-	x3f_printf(DEBUG, "    dev[%d] = %g\n",
-		   color,
-		   sqrt(black_sqdev[color]/pixels));
 	black_sqdev_sum[color] += black_sqdev[color]; 
       }
     }

--- a/src/x3f_process.c
+++ b/src/x3f_process.c
@@ -96,7 +96,8 @@ static int get_black_level(x3f_t *x3f,
       pixels += sum_area(x3f, area[i], colors, black_sum);
 
       for (color = 0; color < colors; color++)
-	x3f_printf(WARN, "XXXX pixels = %d mean[%d] = %f\n",
+	x3f_printf(WARN, "XXXX %d: pixels = %d mean[%d] = %f\n",
+		   i,
 		   pixels,
 		   color,
 		   (double)black_sum[color]/pixels);


### PR DESCRIPTION
Hi, the current pull request is WIP (Work In Progress). So - it shall not be merged.

The solution seems to work.

In the x3f_process.c file there is a debug printout (search for XXXX) that writes the current mean values for the four areas. They are VERY similar - so that is good. Very good. The new left/right areas give the same value as the top/bottom. Nice!

In the x3f_image.c file is the heart of the solution in the function x3f_get_fake_camf_matrix. When getting the two Fake matrix names, it instead fetches the value from the DarkShieldColRange and constricts the matrices. Then, nearly no code needs to be touched, Is that a good solution? I tried to find a better, but could not. But no, it sux. Lets ignore that for now :)

I have two TODO in that function. I have no idea wether the image->rows is the correct value to set. Or - if you need to take keep_area into account.

So - that is it. Please take a look and see if you like it and if you believe in it.

As I said, it make beautiful pictures from the image that previouslu crashed.
