### PR TITLE
Bug 102 sd quattro h faulty bottom black area

### DIFF
--- a/src/x3f_meta.c
+++ b/src/x3f_meta.c
@@ -14,6 +14,36 @@
 #include <stdio.h>
 #include <string.h>
 
+/* extern */ int x3f_get_camf_text(x3f_t *x3f, char *name, char **text)
+{
+  x3f_directory_entry_t *DE = x3f_get_camf(x3f);
+  x3f_directory_entry_header_t *DEH;
+  x3f_camf_t *CAMF;
+  camf_entry_t *table;
+  int i;
+
+  if (!DE) {
+    x3f_printf(DEBUG, "Could not get entry %s: CAMF section not found\n", name);
+    return 0;
+  }
+
+  DEH = &DE->header;
+  CAMF = &DEH->data_subsection.camf;
+  table = CAMF->entry_table.element;
+
+  for (i=0; i<CAMF->entry_table.size; i++) {
+    camf_entry_t *entry = &table[i];
+
+    if (!strcmp(name, entry->name_address)) {
+      if (entry->id != X3F_CMbT) {
+	x3f_printf(DEBUG, "CAMF entry is not text: %s\n", name);
+	return 0;
+      }
+      *text = entry->text;
+    }
+  }
+}
+
 /* extern */ int x3f_get_camf_matrix_var(x3f_t *x3f, char *name,
 					 int *dim0, int *dim1, int *dim2,
 					 matrix_type_t type,

--- a/src/x3f_meta.c
+++ b/src/x3f_meta.c
@@ -39,9 +39,15 @@
 	x3f_printf(DEBUG, "CAMF entry is not text: %s\n", name);
 	return 0;
       }
+
       *text = entry->text;
+      return 1;
     }
   }
+
+  x3f_printf(DEBUG, "CAMF entry not found: %s\n", name);
+
+  return 0;
 }
 
 /* extern */ int x3f_get_camf_matrix_var(x3f_t *x3f, char *name,

--- a/src/x3f_meta.h
+++ b/src/x3f_meta.h
@@ -12,6 +12,8 @@
 
 #include "x3f_io.h"
 
+extern int x3f_get_camf_text(x3f_t *x3f, char *name,
+			     char **text);
 extern int x3f_get_camf_matrix_var(x3f_t *x3f, char *name,
 				   int *dim0, int *dim1, int *dim2,
 				   matrix_type_t type,

--- a/src/x3f_process.c
+++ b/src/x3f_process.c
@@ -63,7 +63,6 @@ static int get_black_level(x3f_t *x3f,
   uint64_t *black, *black_sum;
   double *black_sqdev, *black_sqdev_sum;
   int pixels_sum, i;
-  char *cammodel;
 
   col_side_t side[4] = {COL_SIDE_WRONG,
 			COL_SIDE_WRONG,
@@ -79,11 +78,27 @@ static int get_black_level(x3f_t *x3f,
 
   if (image->channels < colors) return 0;
 
-  /* Workaround for bug in DP2 firmware. DarkShieldBottom is specified
-     incorrectly and thus ingnored. */
 #define BOTTOM 1
-  use[BOTTOM] = (!x3f_get_prop_entry(x3f, "CAMMODEL", &cammodel) ||
-		 strcmp(cammodel, "SIGMA DP2"));
+
+  /* Workaround for bug in DP2 firmware. DarkShieldBottom is specified
+     incorrectly and thus ignored. */
+  {
+    char *cammodel;
+
+    if (x3f_get_prop_entry(x3f, "CAMMODEL", &cammodel))
+      if (!strcmp(cammodel, "SIGMA DP2"))
+	use[BOTTOM] = 0;
+  }
+
+  /* Workaround for bug in sd Quattro H firmaware. DarkShieldBottom is
+     specified incorrectly and thus ignored. */
+  {
+    char *camsettings_info;
+
+    if (x3f_get_camf_text(x3f, "CamsettingsInfo", &camsettings_info))
+      if (!strcmp(camsettings_info, "Camsettings-F23-sdQuattroH"))
+	use[BOTTOM] = 0;
+  }
 
   /* Real CAMF rects */
   for (i=0; i<2; i++)

--- a/src/x3f_process.c
+++ b/src/x3f_process.c
@@ -93,10 +93,10 @@ static int get_black_level(x3f_t *x3f,
   /* Workaround for bug in sd Quattro H firmaware. DarkShieldBottom is
      specified incorrectly and thus ignored. */
   {
-    char *camsettings_info;
+    uint32_t cameraid;
 
-    if (x3f_get_camf_text(x3f, "CamsettingsInfo", &camsettings_info))
-      if (!strcmp(camsettings_info, "Camsettings-F23-sdQuattroH"))
+    if (x3f_get_camf_unsigned(x3f, "CAMERAID", &cameraid))
+      if (cameraid == X3F_CAMERAID_SDQH)
 	use[BOTTOM] = 0;
   }
 


### PR DESCRIPTION
This is a kind of hot fix for sd Quattro H.
It avoids using the faulty bottom area when calculating the dark level.

This do not solve the general problem, that dark areas are a mess on Sigma cameras.

As a side effect, I added x3f_camf_get_text.
I needed this in the first implementation.
But - in the final one I used the integer CAMERAID instead.
So - I left the code in the x3f_meta library, although no one uses it.