### PR TITLE
Fix asserts with side-effects

### DIFF
--- a/src/x3f_image.c
+++ b/src/x3f_image.c
@@ -200,7 +200,8 @@ static int x3f_transform_rect_to_keep_image(x3f_t *x3f,
     return 0;
 
   if (x3f_transform_rect_to_keep_image(x3f, image, rescale, rect)) {
-    assert(x3f_crop_area(rect, image, crop));
+    int ret = x3f_crop_area(rect, image, crop);
+    assert(ret);
     return 1;
   }
 
@@ -216,7 +217,8 @@ static int x3f_transform_rect_to_keep_image(x3f_t *x3f,
   if (!x3f_get_camf_rect(x3f, name, image, rescale, rect)) return 0;
   /* This should not fail as long as x3f_get_camf_rect is implemented
      correctly */
-  assert(x3f_crop_area(rect, image, crop));
+  int ret = x3f_crop_area(rect, image, crop);
+  assert(ret);
 
   return 1;
 }
@@ -231,7 +233,8 @@ static int x3f_transform_rect_to_keep_image(x3f_t *x3f,
     return 0;
   /* This should not fail as long as x3f_get_camf_rect is implemented
      correctly */
-  assert(x3f_crop_area8(rect, image, crop));
+  int ret = x3f_crop_area8(rect, image, crop);
+  assert(ret);
 
   return 1;
 }

--- a/src/x3f_io.c
+++ b/src/x3f_io.c
@@ -1160,7 +1160,8 @@ static char *utf16le_to_utf8(utf16_t *str)
   ibuf = (char *)str;
   obuf = buf;
 
-  assert(iconv(ic, &ibuf, &isize, &obuf, &osize) != -1);
+  int ret = iconv(ic, &ibuf, &isize, &obuf, &osize);
+  assert(ret != -1);
   *obuf = 0;
 
   iconv_close(ic);


### PR DESCRIPTION
This will fix the sigsev problems associated with #110. When doing a release build on Mac, the asserts do not seem to get complied. So none of the asserts would get called, leading to the issues described.

From my limited experience with C I've gather that it's safer to do side-effect/mutating operating outside of the assert and check the return in two steps.

Unrelated to this PR, but I plan on (at least trying to) fix some of the other open issues, especially the Merrill related ones.