### PR TITLE
Fix issue with green tint in Merrill images

### DIFF
--- a/src/x3f_process.c
+++ b/src/x3f_process.c
@@ -79,18 +79,26 @@ static int get_black_level(x3f_t *x3f,
   if (image->channels < colors) return 0;
 
 #define BOTTOM 1
+#define RIGHT 3
 
-  /* Workaround for bug in DP2 firmware. DarkShieldBottom is specified
-     incorrectly and thus ignored. */
+  /* Workaround for bug in DP2 firmware. DarkShieldBottom is specified incorrectly and thus ignored.
+   *
+   * Also, a workaround for the bright "shielded" region on the right for the DP1M, DP2M, and DP3M.
+   * See https://github.com/Kalpanika/x3f/issues/117
+   * */
   {
     char *cammodel;
 
     if (x3f_get_prop_entry(x3f, "CAMMODEL", &cammodel))
-      if (!strcmp(cammodel, "SIGMA DP2"))
-	use[BOTTOM] = 0;
+      if (!strcmp(cammodel, "SIGMA DP2")) {
+        use[BOTTOM] = 0;
+      }
+    if (!strcmp(cammodel, "SIGMA DP1 Merrill") || !strcmp(cammodel, "SIGMA DP2 Merrill") || !strcmp(cammodel, "SIGMA DP3 Merrill")) {
+      use[RIGHT] = 0;
+    }
   }
 
-  /* Workaround for bug in sd Quattro H firmaware. DarkShieldBottom is
+  /* Workaround for bug in sd Quattro H firmware. DarkShieldBottom is
      specified incorrectly and thus ignored. */
   {
     uint32_t cameraid;


### PR DESCRIPTION
The right "shielded" area is not really shielded and can't be used for calculating the black level. Removing this area completely fixes the green tint in the shadows. Closes #117.

Below is a screenshot of the shielded area from the _SDI8040.X3F from x3f_test_files while is a DP2M file. I'm showing the green channel as shown by RawDigger, the red and blue channel are similar (except the red is much noisier and the blue much less noisy).
![x3f](https://user-images.githubusercontent.com/48962821/223903372-46706dd1-4fe4-4199-86a6-e371500b46ea.png)

(As an aside, that region is very conspicuous with its linear increasing exposure may be used for something).